### PR TITLE
Refactor Named Tuples and API Documentation

### DIFF
--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -1,4 +1,4 @@
-name: Upload Python Package
+name: Test and Upload Python Package
 
 on: [push]
 
@@ -18,10 +18,14 @@ jobs:
     - name: Check formatting
       run: |
         poetry run black --check wknml tests examples
-    - name: Test
+    - name: Unit Tests
       run: |
         mkdir -p testoutput
         poetry run pytest tests
+    - name: Check Documentation for updates
+      run: |
+        poetry run pydoc-markdown -m wknml --render-toc > docs/ci_test.md
+        diff docs/ci_test.md docs/wknml.md
     - name: Build and publish
       if: startsWith(github.event.ref, 'refs/tags')
       env:

--- a/.github/workflows/python-module.yml
+++ b/.github/workflows/python-module.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         poetry run pydoc-markdown -m wknml --render-toc > docs/ci_test.md
         diff docs/ci_test.md docs/wknml.md
+        rm docs/ci_test.md
     - name: Build and publish
       if: startsWith(github.event.ref, 'refs/tags')
       env:

--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@ To use wknml, you need to have Python 3.6+ (on the system or with Anaconda) inst
 pip install wknml
 ```
 
-## Example Snippets
-Some example to get you started. Make sure to also check the `examples` directory:
-```
+## Documentation
+
+See [docs/wknml.md](docs/wknml.md) for an API documentation.
+
+## Examples
+
+Some examples to get you started. Make sure to also check the `examples` directory:
+
+```python
 # Load an NML file
 with open("input.nml", "rb") as f:
     nml = wknml.parse_nml(f, nml)
@@ -33,7 +39,6 @@ for tree in nml.trees:
 # Write a new NML file to disk
 with open("out.nml", "wb") as f:
     wknml.write_nml(f, nml)
-```
 
 
 # Convert an NML file with unlinked nodes to one with connected trees
@@ -57,6 +62,11 @@ poetry run pytest tests
 PyPi releases are automatically pushed when creating a new Git tag/Github release. Make sure to bump the package version number manually:
 ```
 poetry version <patch, minor, major>
+```
+
+If necessary, rebuild the documentation and commit to repository:
+```
+poetry run pydoc-markdown -m wknml --render-toc > docs/wknml.md
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -11,11 +11,30 @@ To use wknml, you need to have Python 3.6+ (on the system or with Anaconda) inst
 pip install wknml
 ```
 
-## Snippets
+## Example Snippets
+Some example to get you started. Make sure to also check the `examples` directory:
 ```
-# Check out the repository and go into it
-git clone git@github.com:scalableminds/wknml.git
-cd wknml
+# Load an NML file
+with open("input.nml", "rb") as f:
+    nml = wknml.parse_nml(f, nml)
+
+# Access the most important properties
+print(nml.parameters)
+print(nml.trees)
+print(nml.branchpoints)
+print(nml.comments)
+print(nml.groups)
+
+# Iterate over all nodes
+for tree in nml.trees:
+    for node in tree.nodes:
+        print(tree, node)
+
+# Write a new NML file to disk
+with open("out.nml", "wb") as f:
+    wknml.write_nml(f, nml)
+```
+
 
 # Convert an NML file with unlinked nodes to one with connected trees
 python -m examples.fix_unlinked_nml <unlinked>.nml <fixed>.nml

--- a/docs/wknml.md
+++ b/docs/wknml.md
@@ -26,15 +26,15 @@ Contains common metadata for NML files
 
 **Attributes**:
 
-- `name` _str_ - Foo
-- `scale` _Vector3_ - Foo
-- `offset` _Optional[Vector3]_ - Foo
-- `time` _Optional[int]_ - Foo
-- `editPosition` _Optional[Vector3]_ - Foo
-- `editRotation` _Optional[Vector3]_ - Foo
-- `zoomLevel` _Optional[float]_ - Foo
-  taskBoundingBox (Optional[IntVector6])
-  userBoundingBox (Optional[IntVector6])
+- `name` - str
+- `scale` - Vector3
+- `offset` - Optional[Vector3]
+- `time` - Optional[int]
+- `editPosition` - Optional[Vector3]
+- `editRotation` - Optional[Vector3]
+- `zoomLevel` - Optional[float]
+- `taskBoundingBox` - Optional[IntVector6]
+- `userBoundingBox` - Optional[IntVector6]
 
 <a name="wknml.Node"></a>
 ## Node Objects
@@ -68,8 +68,8 @@ A webKnossos skeleton edge.
 
 **Attributes**:
 
-- `source` - int (node id reference)
-- `target` - int (node id reference)
+- `source` _int_ - node id reference
+- `target` _int_ - node id reference
 
 <a name="wknml.Tree"></a>
 ## Tree Objects
@@ -83,11 +83,11 @@ A webKnossos skeleton (tree) object. A graph structure consisting of nodes and e
 **Attributes**:
 
 - `id` - int
-- `color` - Vector4 (RGBA)
+- `color` _Vector4_ - RGBA
 - `name` - str
 - `nodes` - List[Node]
 - `edges` - List[Edge]
-- `groupId` - Optional[int] (group id reference)
+- `groupId` _Optional[int]_ - group id reference
 
 <a name="wknml.Branchpoint"></a>
 ## Branchpoint Objects
@@ -100,8 +100,8 @@ A webKnossos branchpoint, i.e. a skeleton node with more than one outgoing edge.
 
 **Attributes**:
 
-- `id` - int (node id reference)
-- `time` - int (Unix timestamp)
+- `id` _int_ - node id reference
+- `time` _int_ - Unix timestamp
 
 <a name="wknml.Group"></a>
 ## Group Objects
@@ -129,8 +129,8 @@ A single comment belonging to a skeleton node.
 
 **Attributes**:
 
-- `node` - int (node id reference)
-- `content` - str (supports Markdown)
+- `node` _int_ - node id reference
+- `content` _str_ - supports Markdown
 
 <a name="wknml.NML"></a>
 ## NML Objects

--- a/docs/wknml.md
+++ b/docs/wknml.md
@@ -1,0 +1,195 @@
+# Table of Contents
+
+* [wknml](#wknml)
+  * [NMLParameters](#wknml.NMLParameters)
+  * [Node](#wknml.Node)
+  * [Edge](#wknml.Edge)
+  * [Tree](#wknml.Tree)
+  * [Branchpoint](#wknml.Branchpoint)
+  * [Group](#wknml.Group)
+  * [Comment](#wknml.Comment)
+  * [NML](#wknml.NML)
+  * [parse\_nml](#wknml.parse_nml)
+  * [write\_nml](#wknml.write_nml)
+
+<a name="wknml"></a>
+# wknml
+
+<a name="wknml.NMLParameters"></a>
+## NMLParameters Objects
+
+```python
+class NMLParameters(NamedTuple)
+```
+
+Contains common metadata for NML files
+
+**Attributes**:
+
+- `name` _str_ - Foo
+- `scale` _Vector3_ - Foo
+- `offset` _Optional[Vector3]_ - Foo
+- `time` _Optional[int]_ - Foo
+- `editPosition` _Optional[Vector3]_ - Foo
+- `editRotation` _Optional[Vector3]_ - Foo
+- `zoomLevel` _Optional[float]_ - Foo
+  taskBoundingBox (Optional[IntVector6])
+  userBoundingBox (Optional[IntVector6])
+
+<a name="wknml.Node"></a>
+## Node Objects
+
+```python
+class Node(NamedTuple)
+```
+
+A webKnossos skeleton node annotation object.
+
+**Attributes**:
+
+- `id` - int
+- `position` - Vector3
+- `radius` - Optional[float]
+- `rotation` - Optional[Vector3]
+- `inVp` - Optional[int]
+- `inMag` - Optional[int]
+- `bitDepth` - Optional[int]
+- `interpolation` - Optional[bool]
+- `time` - Optional[int]
+
+<a name="wknml.Edge"></a>
+## Edge Objects
+
+```python
+class Edge(NamedTuple)
+```
+
+A webKnossos skeleton edge.
+
+**Attributes**:
+
+- `source` - int (node id reference)
+- `target` - int (node id reference)
+
+<a name="wknml.Tree"></a>
+## Tree Objects
+
+```python
+class Tree(NamedTuple)
+```
+
+A webKnossos skeleton (tree) object. A graph structure consisting of nodes and edges.
+
+**Attributes**:
+
+- `id` - int
+- `color` - Vector4 (RGBA)
+- `name` - str
+- `nodes` - List[Node]
+- `edges` - List[Edge]
+- `groupId` - Optional[int] (group id reference)
+
+<a name="wknml.Branchpoint"></a>
+## Branchpoint Objects
+
+```python
+class Branchpoint(NamedTuple)
+```
+
+A webKnossos branchpoint, i.e. a skeleton node with more than one outgoing edge.
+
+**Attributes**:
+
+- `id` - int (node id reference)
+- `time` - int (Unix timestamp)
+
+<a name="wknml.Group"></a>
+## Group Objects
+
+```python
+class Group(NamedTuple)
+```
+
+A container to group several skeletons (trees) together. Mostly for cosmetic or organizational purposes.
+
+**Attributes**:
+
+- `id` - int
+- `name` - str
+- `children` - List[Group]
+
+<a name="wknml.Comment"></a>
+## Comment Objects
+
+```python
+class Comment(NamedTuple)
+```
+
+A single comment belonging to a skeleton node.
+
+**Attributes**:
+
+- `node` - int (node id reference)
+- `content` - str (supports Markdown)
+
+<a name="wknml.NML"></a>
+## NML Objects
+
+```python
+class NML(NamedTuple)
+```
+
+A complete webKnossos skeleton annotation object contain one or more skeletons (trees).
+
+**Attributes**:
+
+- `parameters` - NMLParameters
+- `trees` - List[Tree]
+- `branchpoints` - List[Branchpoint]
+- `comments` - List[Comment]
+- `groups` - List[Group]
+
+<a name="wknml.parse_nml"></a>
+#### parse\_nml
+
+```python
+parse_nml(file: BinaryIO) -> NML
+```
+
+Reads a webKnossos NML skeleton file from disk, parses it and returns an NML Python object
+
+**Attributes**:
+
+- `file` _BinaryIO_ - A Python file handle
+  
+
+**Returns**:
+
+- `NML` - A webKnossos skeleton annotation as Python NML object
+  
+
+**Example**:
+
+  with open("input.nml", "rb") as f:
+  nml = wknml.parse_nml(f, nml)
+
+<a name="wknml.write_nml"></a>
+#### write\_nml
+
+```python
+write_nml(file: BinaryIO, nml: NML)
+```
+
+Writes an NML object to a file on disk.
+
+**Arguments**:
+
+- `file` _BinaryIO_ - A Python file handle
+- `nml` _NML_ - A NML object that should be persisted to disk
+  
+
+**Example**:
+
+  with open("out.nml", "wb") as f:
+  wknml.write_nml(f, nml)
+

--- a/docs/wknml.md
+++ b/docs/wknml.md
@@ -170,8 +170,10 @@ Reads a webKnossos NML skeleton file from disk, parses it and returns an NML Pyt
 
 **Example**:
 
+  ```
   with open("input.nml", "rb") as f:
   nml = wknml.parse_nml(f, nml)
+  ```
 
 <a name="wknml.write_nml"></a>
 #### write\_nml
@@ -190,6 +192,8 @@ Writes an NML object to a file on disk.
 
 **Example**:
 
+  ```
   with open("out.nml", "wb") as f:
   wknml.write_nml(f, nml)
+  ```
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -52,6 +52,22 @@ colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
+name = "certifi"
+version = "2020.11.8"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "chardet"
+version = "3.0.4"
+description = "Universal encoding detector for Python 2 and 3"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "click"
 version = "7.1.2"
 description = "Composable command line interface toolkit"
@@ -82,6 +98,38 @@ description = "Decorators for Humans"
 category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+
+[[package]]
+name = "docspec"
+version = "0.2.0"
+description = "Docspec is a JSON object specification for representing API documentation of programming languages."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+"nr.databind.core" = ">=0.0.19,<0.1.0"
+"nr.databind.json" = ">=0.0.9,<0.1.0"
+
+[[package]]
+name = "docspec-python"
+version = "0.0.7"
+description = "A parser based on lib2to3 producing docspec data from Python source code."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+docspec = ">=0.2.0,<0.3.0"
+"nr.sumtype" = ">=0.0.3,<0.1.0"
+
+[[package]]
+name = "idna"
+version = "2.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
@@ -147,6 +195,138 @@ pyyaml = ["pyyaml"]
 scipy = ["scipy"]
 
 [[package]]
+name = "nr.collections"
+version = "0.0.1"
+description = "Useful container datatypes for Python 2 and 3."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+"nr.metaclass" = ">=0.0.1,<0.1.0"
+six = ">=1.11.0,<2.0.0"
+
+[package.extras]
+test = ["nr.fs (>=1.5.0,<2.0.0)"]
+
+[[package]]
+name = "nr.databind.core"
+version = "0.0.22"
+description = "Bind structured data directly to typed objects."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+"nr.collections" = ">=0.0.1,<1.0.0"
+"nr.interface" = ">=0.0.1,<0.1.0"
+"nr.pylang.utils" = ">=0.0.3,<0.1.0"
+"nr.stream" = ">=0.0.1,<0.1.0"
+
+[[package]]
+name = "nr.databind.json"
+version = "0.0.14"
+description = "Deserialize JSON into Python objects and reverse."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+"nr.collections" = ">=0.0.1,<1.0.0"
+"nr.databind.core" = ">=0.0.21,<0.1.0"
+"nr.interface" = ">=0.0.1,<0.1.0"
+"nr.parsing.date" = ">=0.1.0,<1.0.0"
+"nr.pylang.utils" = ">=0.0.1,<0.1.0"
+
+[[package]]
+name = "nr.fs"
+version = "1.6.3"
+description = "Filesystem and path manipulation tools."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.11.0,<2.0.0"
+
+[[package]]
+name = "nr.interface"
+version = "0.0.4"
+description = "Interface definitions for Python."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+"nr.collections" = ">=0.0.1,<1.0.0"
+"nr.metaclass" = ">=0.0.1,<0.1.0"
+"nr.pylang.utils" = ">=0.0.1,<0.1.0"
+six = ">=1.11.0,<2.0.0"
+
+[[package]]
+name = "nr.metaclass"
+version = "0.0.6"
+description = "Metaclass utilities."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "nr.parsing.date"
+version = "0.4.3"
+description = "A simple and fast date parsing library. Uses dateutil for timezone offset support."
+category = "dev"
+optional = false
+python-versions = ">=3.5.0,<4.0.0"
+
+[package.dependencies]
+"nr.utils.re" = ">=0.1.0,<0.2.0"
+
+[[package]]
+name = "nr.pylang.utils"
+version = "0.0.4"
+description = "Package description here."
+category = "dev"
+optional = false
+python-versions = ">=3.4.0,<4.0.0"
+
+[package.dependencies]
+"nr.collections" = ">=0.0.1,<1.0.0"
+
+[[package]]
+name = "nr.stream"
+version = "0.0.5"
+description = "Use iterators like Java streams."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+"nr.collections" = ">=0.0.1,<1.0.0"
+"nr.pylang.utils" = ">=0.0.1,<1.0.0"
+six = ">=1.11.0,<2.0.0"
+
+[[package]]
+name = "nr.sumtype"
+version = "0.0.4"
+description = "Sumtypes in Python."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+"nr.metaclass" = ">=0.0.4,<1.0.0"
+"nr.stream" = ">=0.0.2,<1.0.0"
+
+[[package]]
+name = "nr.utils.re"
+version = "0.1.1"
+description = "This module provides some utility functions for applying regular expressions."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "numpy"
 version = "1.19.4"
 description = "NumPy is the fundamental package for array computing with Python."
@@ -174,6 +354,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "pathtools"
+version = "0.1.2"
+description = "File system general utilities"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pluggy"
 version = "0.13.1"
 description = "plugin and hook calling mechanisms for python"
@@ -194,6 +382,29 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pydoc-markdown"
+version = "3.8.0"
+description = "Create Python API documentation in Markdown format."
+category = "dev"
+optional = false
+python-versions = ">=3.5.0,<4.0.0"
+
+[package.dependencies]
+click = ">=7.0.0,<8.0.0"
+docspec = ">=0.2.0,<0.3.0"
+docspec-python = ">=0.0.7,<0.1.0"
+"nr.collections" = ">=0.0.1,<0.1.0"
+"nr.databind.core" = ">=0.0.18,<0.1.0"
+"nr.databind.json" = ">=0.0.9,<0.1.0"
+"nr.fs" = ">=1.6.0,<2.0.0"
+"nr.interface" = ">=0.0.3,<0.1.0"
+PyYAML = ">=5.3.0,<6.0.0"
+requests = ">=2.23.0,<3.0.0"
+six = ">=1.11.0,<2.0.0"
+toml = ">=0.10.1,<1.0.0"
+watchdog = ">=0.10.2,<1.0.0"
 
 [[package]]
 name = "pyparsing"
@@ -227,12 +438,46 @@ checkqa_mypy = ["mypy (==0.780)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "pyyaml"
+version = "5.3.1"
+description = "YAML parser and emitter for Python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "regex"
 version = "2020.11.13"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "requests"
+version = "2.25.0"
+description = "Python HTTP for Humans."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<4"
+idna = ">=2.5,<3"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+
+[[package]]
+name = "six"
+version = "1.15.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "toml"
@@ -259,6 +504,33 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "urllib3"
+version = "1.26.2"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "watchdog"
+version = "0.10.4"
+description = "Filesystem events monitoring"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pathtools = ">=0.1.1"
+
+[package.extras]
+watchmedo = ["PyYAML (>=3.10)", "argh (>=0.24.1)"]
+
+[[package]]
 name = "zipp"
 version = "3.4.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -273,7 +545,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "1d76bbf65ed843d258949d78c1c8a8ab5cd02fff972d997ac7041d71f52d7aab"
+content-hash = "d53d47f70c6462de48eb74b3b5d4d20dd39f499f36da58998570dcddfea4b15f"
 
 [metadata.files]
 appdirs = [
@@ -291,6 +563,14 @@ attrs = [
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
+certifi = [
+    {file = "certifi-2020.11.8-py2.py3-none-any.whl", hash = "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd"},
+    {file = "certifi-2020.11.8.tar.gz", hash = "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"},
+]
+chardet = [
+    {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
+    {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
+]
 click = [
     {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
     {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
@@ -306,6 +586,18 @@ dataclasses = [
 decorator = [
     {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
     {file = "decorator-4.4.2.tar.gz", hash = "sha256:e3a62f0520172440ca0dcc823749319382e377f37f140a0b99ef45fecb84bfe7"},
+]
+docspec = [
+    {file = "docspec-0.2.0-py3-none-any.whl", hash = "sha256:a5bf4bfe5e940de080b282045db4f2a6aea3e745f639d34262f59791fb18107c"},
+    {file = "docspec-0.2.0.tar.gz", hash = "sha256:058894861bff860f7053188c94cbd55d1777d5d0f39f3f8487960965ab098191"},
+]
+docspec-python = [
+    {file = "docspec-python-0.0.7.tar.gz", hash = "sha256:13af366a2dc0efdc7488f7560ad169ee80992f7f792a6b8d7ad0097bba7a27ab"},
+    {file = "docspec_python-0.0.7-py3-none-any.whl", hash = "sha256:9949eda3f964aacdf39d5c84e24a72464e7e190d982cbb2714e661124fa03524"},
+]
+idna = [
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-3.1.1-py3-none-any.whl", hash = "sha256:6112e21359ef8f344e7178aa5b72dc6e62b38b0d008e6d3cb212c5b84df72013"},
@@ -325,6 +617,49 @@ mypy-extensions = [
 networkx = [
     {file = "networkx-2.5-py3-none-any.whl", hash = "sha256:8c5812e9f798d37c50570d15c4a69d5710a18d77bafc903ee9c5fba7454c616c"},
     {file = "networkx-2.5.tar.gz", hash = "sha256:7978955423fbc9639c10498878be59caf99b44dc304c2286162fd24b458c1602"},
+]
+"nr.collections" = [
+    {file = "nr.collections-0.0.1.tar.gz", hash = "sha256:ddf38cd6379cac546ce7abdadf024fc01cca75540e11b1d5f1aa701a33817f1c"},
+]
+"nr.databind.core" = [
+    {file = "nr.databind.core-0.0.22-py2.py3-none-any.whl", hash = "sha256:854a0a0551a0aa5a5acedaa547af930bdaca331bc705b3f26732f6b913491572"},
+    {file = "nr.databind.core-0.0.22.tar.gz", hash = "sha256:87fe32d7d8dd91b878a25cd144d056435107ca56a8db7be3030f765334075f77"},
+]
+"nr.databind.json" = [
+    {file = "nr.databind.json-0.0.14-py2.py3-none-any.whl", hash = "sha256:3765fd581c2ca2ee249ccfd460be0f472cc2bc9e5305e2f415d587a5e27c3b86"},
+    {file = "nr.databind.json-0.0.14.tar.gz", hash = "sha256:27c7a7a69f6f703a0c616b898950fdb53a51b39cf9874d412ebc12dea574f20e"},
+]
+"nr.fs" = [
+    {file = "nr.fs-1.6.3-py2.py3-none-any.whl", hash = "sha256:64108c168ea2e8077fdf5f0c5417459d1a145fe34cb305fe90faeb75b4e8b421"},
+    {file = "nr.fs-1.6.3.tar.gz", hash = "sha256:788aa0a04c4143f95c5245bc8ccc0c0872e932be533bd37780fbb55afcdf124a"},
+]
+"nr.interface" = [
+    {file = "nr.interface-0.0.4-py2.py3-none-any.whl", hash = "sha256:5f88579643ea18e1d948d92a49b326aa4585516bf64eb529ae693c4c8bddcc6e"},
+    {file = "nr.interface-0.0.4.tar.gz", hash = "sha256:285cd82b932427c9d5c21cdc02ad319f701c4eed201377e2b30485c91eac67a3"},
+]
+"nr.metaclass" = [
+    {file = "nr.metaclass-0.0.6-py2.py3-none-any.whl", hash = "sha256:d458eb1bddd93373cc74e19981214e7d478c92c9b08fc9732bd430225698a8f0"},
+    {file = "nr.metaclass-0.0.6.tar.gz", hash = "sha256:3d52f8e603e3c2944b9135e5a09593c3c36191f26cf1c29a7c71efb192552b10"},
+]
+"nr.parsing.date" = [
+    {file = "nr.parsing.date-0.4.3-py3-none-any.whl", hash = "sha256:899ee068883ce43cd6502915121b6667470b9cad10d4753f74db6d7ca23ac5b3"},
+    {file = "nr.parsing.date-0.4.3.tar.gz", hash = "sha256:540b926a6e9b5d0f2b042b614c094ca08d6445227e2769d0ca5581fb459b3cd3"},
+]
+"nr.pylang.utils" = [
+    {file = "nr.pylang.utils-0.0.4-py3-none-any.whl", hash = "sha256:cf8c88b9e7821a256e31e83e16dcd506d1fb33ea3cf37578eb163526ab044a27"},
+    {file = "nr.pylang.utils-0.0.4.tar.gz", hash = "sha256:48f81167a5f0a7376b0dd1b3db2b88ab1cfa815645a2d4048eb369564f4e2485"},
+]
+"nr.stream" = [
+    {file = "nr.stream-0.0.5-py2.py3-none-any.whl", hash = "sha256:cf418a4de3cedb8622286d2baca6007a153c780af48362d1f2ef2c1993525615"},
+    {file = "nr.stream-0.0.5.tar.gz", hash = "sha256:3489ce5e8174b70d194a6592248ba341fbbd5bf30c9ec5f1223a351df909f505"},
+]
+"nr.sumtype" = [
+    {file = "nr.sumtype-0.0.4-py2.py3-none-any.whl", hash = "sha256:a1017468bbc3d187592c413892c19d0e9642bdeae0149fa0c122ca21dfb23132"},
+    {file = "nr.sumtype-0.0.4.tar.gz", hash = "sha256:a224c7f70c212aebf3754cf941d94527e68f1afad8db0e224d9885eb113d797c"},
+]
+"nr.utils.re" = [
+    {file = "nr.utils.re-0.1.1-py2.py3-none-any.whl", hash = "sha256:eb4e6c10b074e8b296c4e2a83d0299e9a162524fb3e5e6b916dfd194688dbd06"},
+    {file = "nr.utils.re-0.1.1.tar.gz", hash = "sha256:71e21300dbf890d914841f1e6d66eb4e7d6a9f01c9a20d8e83e5242c8d3140aa"},
 ]
 numpy = [
     {file = "numpy-1.19.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e9b30d4bd69498fc0c3fe9db5f62fffbb06b8eb9321f92cc970f2969be5e3949"},
@@ -370,6 +705,9 @@ pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
     {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
+pathtools = [
+    {file = "pathtools-0.1.2.tar.gz", hash = "sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0"},
+]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
@@ -378,6 +716,10 @@ py = [
     {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
     {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
 ]
+pydoc-markdown = [
+    {file = "pydoc-markdown-3.8.0.tar.gz", hash = "sha256:5648b1a3e32031649b68a3c699f363ae8a168b0d9dd4d25767804ce8fe6c8b2b"},
+    {file = "pydoc_markdown-3.8.0-py3-none-any.whl", hash = "sha256:e497f406c6adbdad92ed7e78614a6e214ddb5f2e52aadcc8e8d11fc0b03ab808"},
+]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
@@ -385,6 +727,19 @@ pyparsing = [
 pytest = [
     {file = "pytest-6.1.2-py3-none-any.whl", hash = "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe"},
     {file = "pytest-6.1.2.tar.gz", hash = "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"},
+]
+pyyaml = [
+    {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
+    {file = "PyYAML-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2"},
+    {file = "PyYAML-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2"},
+    {file = "PyYAML-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"},
+    {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
+    {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
+    {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 regex = [
     {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},
@@ -429,6 +784,14 @@ regex = [
     {file = "regex-2020.11.13-cp39-cp39-win_amd64.whl", hash = "sha256:a15f64ae3a027b64496a71ab1f722355e570c3fac5ba2801cafce846bf5af01d"},
     {file = "regex-2020.11.13.tar.gz", hash = "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562"},
 ]
+requests = [
+    {file = "requests-2.25.0-py2.py3-none-any.whl", hash = "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"},
+    {file = "requests-2.25.0.tar.gz", hash = "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8"},
+]
+six = [
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
@@ -460,6 +823,13 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
     {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.2-py2.py3-none-any.whl", hash = "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"},
+    {file = "urllib3-1.26.2.tar.gz", hash = "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"},
+]
+watchdog = [
+    {file = "watchdog-0.10.4.tar.gz", hash = "sha256:e38bffc89b15bafe2a131f0e1c74924cf07dcec020c2e0a26cccd208831fcd43"},
 ]
 zipp = [
     {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ numpy = "^1.19.4"
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"
 pytest = "^6.1.2"
+pydoc-markdown = "^3.8.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wknml"
-version = "0.0.11"
+version = "1.0.0"
 description = "Python package to work with webKnossos NML skeleton files"
 authors = ["scalable minds <hello@scalableminds.com>"]
 license = "MIT"

--- a/wknml/__init__.py
+++ b/wknml/__init__.py
@@ -8,7 +8,7 @@ IntVector6 = Tuple[int, int, int, int, int, int]
 
 
 class NMLParameters(NamedTuple):
-    '''
+    """
     Contains common metadata for NML files
 
     Attributes:
@@ -21,7 +21,8 @@ class NMLParameters(NamedTuple):
         zoomLevel: Optional[float]
         taskBoundingBox: Optional[IntVector6]
         userBoundingBox: Optional[IntVector6]
-    '''
+    """
+
     name: str
     scale: Vector3
     offset: Optional[Vector3]
@@ -34,7 +35,7 @@ class NMLParameters(NamedTuple):
 
 
 class Node(NamedTuple):
-    '''
+    """
     A webKnossos skeleton node annotation object.
 
     Attributes:
@@ -47,7 +48,8 @@ class Node(NamedTuple):
         bitDepth: Optional[int]
         interpolation: Optional[bool]
         time: Optional[int]
-    '''
+    """
+
     id: int
     position: Vector3
     radius: Optional[float]
@@ -60,19 +62,20 @@ class Node(NamedTuple):
 
 
 class Edge(NamedTuple):
-    ''' 
+    """
     A webKnossos skeleton edge.
 
     Attributes:
         source (int): node id reference
         target (int): node id reference
-    ''' 
+    """
+
     source: int
     target: int
 
 
 class Tree(NamedTuple):
-    ''' 
+    """
     A webKnossos skeleton (tree) object. A graph structure consisting of nodes and edges.
 
     Attributes:
@@ -82,7 +85,8 @@ class Tree(NamedTuple):
         nodes: List[Node]
         edges: List[Edge]
         groupId (Optional[int]): group id reference
-    ''' 
+    """
+
     id: int
     color: Vector4
     name: str
@@ -92,46 +96,49 @@ class Tree(NamedTuple):
 
 
 class Branchpoint(NamedTuple):
-    ''' 
+    """
     A webKnossos branchpoint, i.e. a skeleton node with more than one outgoing edge.
 
     Attributes:
         id (int): node id reference
         time (int): Unix timestamp
-    ''' 
+    """
+
     id: int
     time: int
 
 
 class Group(NamedTuple):
-    '''
+    """
     A container to group several skeletons (trees) together. Mostly for cosmetic or organizational purposes.
 
     Attributes:
         id: int
         name: str
         children: List[Group]
-    '''
+    """
+
     id: int
     name: str
     children: List["Group"]
 
 
 class Comment(NamedTuple):
-    '''
+    """
     A single comment belonging to a skeleton node.
 
     Attributes:
         node (int): node id reference
         content (str): supports Markdown
-    ''' 
+    """
+
     node: int
     content: str
 
 
 class NML(NamedTuple):
-    '''
-    A complete webKnossos skeleton annotation object contain one or more skeletons (trees). 
+    """
+    A complete webKnossos skeleton annotation object contain one or more skeletons (trees).
 
     Attributes:
         parameters: NMLParameters
@@ -139,7 +146,8 @@ class NML(NamedTuple):
         branchpoints: List[Branchpoint]
         comments: List[Comment]
         groups: List[Group]
-    ''' 
+    """
+
     parameters: NMLParameters
     trees: List[Tree]
     branchpoints: List[Branchpoint]
@@ -308,7 +316,7 @@ def __parse_group(nml_group):
 
 
 def parse_nml(file: BinaryIO) -> NML:
-    '''
+    """
     Reads a webKnossos NML skeleton file from disk, parses it and returns an NML Python object
 
     Attributes:
@@ -320,7 +328,7 @@ def parse_nml(file: BinaryIO) -> NML:
     Example:
         with open("input.nml", "rb") as f:
             nml = wknml.parse_nml(f, nml)
-    '''
+    """
 
     parameters = None
     trees = []
@@ -559,16 +567,16 @@ def __dump_nml(xf, nml: NML):
 
 
 def write_nml(file: BinaryIO, nml: NML):
-    ''' 
+    """
     Writes an NML object to a file on disk.
 
     Arguments:
         file (BinaryIO): A Python file handle
-        nml (NML): A NML object that should be persisted to disk 
-    
+        nml (NML): A NML object that should be persisted to disk
+
     Example:
         with open("out.nml", "wb") as f:
             wknml.write_nml(f, nml)
-    ''' 
+    """
     with XmlWriter(file) as xf:
         __dump_nml(xf, nml)

--- a/wknml/__init__.py
+++ b/wknml/__init__.py
@@ -12,15 +12,15 @@ class NMLParameters(NamedTuple):
     Contains common metadata for NML files
 
     Attributes:
-        name (str): Foo
-        scale (Vector3): Foo
-        offset (Optional[Vector3]): Foo
-        time (Optional[int]): Foo
-        editPosition (Optional[Vector3]): Foo
-        editRotation (Optional[Vector3]): Foo
-        zoomLevel (Optional[float]): Foo
-        taskBoundingBox (Optional[IntVector6])
-        userBoundingBox (Optional[IntVector6])
+        name: str
+        scale: Vector3
+        offset: Optional[Vector3]
+        time: Optional[int]
+        editPosition: Optional[Vector3]
+        editRotation: Optional[Vector3]
+        zoomLevel: Optional[float]
+        taskBoundingBox: Optional[IntVector6]
+        userBoundingBox: Optional[IntVector6]
     '''
     name: str
     scale: Vector3
@@ -64,8 +64,8 @@ class Edge(NamedTuple):
     A webKnossos skeleton edge.
 
     Attributes:
-        source: int (node id reference)
-        target: int (node id reference)
+        source (int): node id reference
+        target (int): node id reference
     ''' 
     source: int
     target: int
@@ -77,11 +77,11 @@ class Tree(NamedTuple):
 
     Attributes:
         id: int
-        color: Vector4 (RGBA)
+        color (Vector4): RGBA
         name: str
         nodes: List[Node]
         edges: List[Edge]
-        groupId: Optional[int] (group id reference)
+        groupId (Optional[int]): group id reference
     ''' 
     id: int
     color: Vector4
@@ -96,8 +96,8 @@ class Branchpoint(NamedTuple):
     A webKnossos branchpoint, i.e. a skeleton node with more than one outgoing edge.
 
     Attributes:
-        id: int (node id reference)
-        time: int (Unix timestamp)
+        id (int): node id reference
+        time (int): Unix timestamp
     ''' 
     id: int
     time: int
@@ -122,8 +122,8 @@ class Comment(NamedTuple):
     A single comment belonging to a skeleton node.
 
     Attributes:
-        node: int (node id reference)
-        content: str (supports Markdown)
+        node (int): node id reference
+        content (str): supports Markdown
     ''' 
     node: int
     content: str

--- a/wknml/__init__.py
+++ b/wknml/__init__.py
@@ -1,6 +1,6 @@
 import xml.etree.ElementTree as ET
 from loxun import XmlWriter
-from typing import NamedTuple, List, Tuple, Optional
+from typing import BinaryIO, NamedTuple, List, Tuple, Optional
 
 Vector3 = Tuple[float, float, float]
 Vector4 = Tuple[float, float, float, float]
@@ -69,7 +69,7 @@ class NML(NamedTuple):
     groups: List[Group]
 
 
-def parse_bounding_box(nml_parameters, prefix):
+def __parse_bounding_box(nml_parameters, prefix):
     boundingBox = None
     bboxName = prefix + "BoundingBox"
     if nml_parameters.find(bboxName) is not None:
@@ -84,7 +84,7 @@ def parse_bounding_box(nml_parameters, prefix):
     return boundingBox
 
 
-def parse_parameters(nml_parameters):
+def __parse_parameters(nml_parameters):
     offset = None
     if nml_parameters.find("offset") is not None:
         offset = (
@@ -117,8 +117,8 @@ def parse_parameters(nml_parameters):
     if nml_parameters.find("zoomLevel") is not None:
         zoomLevel = nml_parameters.find("zoomLevel").get("zoom")
 
-    taskBoundingBox = parse_bounding_box(nml_parameters, "task")
-    userBoundingBox = parse_bounding_box(nml_parameters, "user")
+    taskBoundingBox = __parse_bounding_box(nml_parameters, "task")
+    userBoundingBox = __parse_bounding_box(nml_parameters, "user")
 
     return NMLParameters(
         name=nml_parameters.find("experiment").get("name"),
@@ -137,7 +137,7 @@ def parse_parameters(nml_parameters):
     )
 
 
-def parse_node(nml_node):
+def __parse_node(nml_node):
     rotation = None
     if nml_node.get("rotX") is not None:
         rotation = (
@@ -169,11 +169,11 @@ def parse_node(nml_node):
     )
 
 
-def parse_edge(nml_edge):
+def __parse_edge(nml_edge):
     return Edge(source=int(nml_edge.get("source")), target=int(nml_edge.get("target")))
 
 
-def parse_tree(nml_tree):
+def __parse_tree(nml_tree):
     name = None
     if "comment" in nml_tree.attrib:
         name = nml_tree.get("comment")
@@ -210,7 +210,7 @@ def parse_tree(nml_tree):
     )
 
 
-def parse_branchpoint(nml_branchpoint):
+def __parse_branchpoint(nml_branchpoint):
     return Branchpoint(
         int(nml_branchpoint.get("id")),
         int(nml_branchpoint.get("time"))
@@ -219,17 +219,21 @@ def parse_branchpoint(nml_branchpoint):
     )
 
 
-def parse_comment(nml_comment):
+def __parse_comment(nml_comment):
     return Comment(
         int(nml_comment.get("node")), nml_comment.get("content", default=None)
     )
 
 
-def parse_group(nml_group):
+def __parse_group(nml_group):
     return Group(int(nml_group.get("id")), nml_group.get("name", default=None), [])
 
 
-def parse_nml(file):
+def parse_nml(file: BinaryIO) -> NML:
+    '''
+        Parses a webKnossos NML skeleton file and returns an NML Python object
+    '''
+
     parameters = None
     trees = []
     branchpoints = []
@@ -243,29 +247,29 @@ def parse_nml(file):
         if event == "start":
             element_stack.append(elem)
             if elem.tag == "thing":
-                current_tree = parse_tree(elem)
+                current_tree = __parse_tree(elem)
                 trees.append(current_tree)
             elif elem.tag == "node":
                 assert (
                     current_tree is not None
                 ), "<node ...> tag needs to be child of a <thing ...> tag."
-                current_tree.nodes.append(parse_node(elem))
+                current_tree.nodes.append(__parse_node(elem))
             elif elem.tag == "edge":
                 assert (
                     current_tree is not None
                 ), "<edge ...> tag needs to be child of a <thing ...> tag."
-                current_tree.edges.append(parse_edge(elem))
+                current_tree.edges.append(__parse_edge(elem))
             elif elem.tag == "branchpoint":
-                branchpoints.append(parse_branchpoint(elem))
+                branchpoints.append(__parse_branchpoint(elem))
             elif elem.tag == "comment":
-                comments.append(parse_comment(elem))
+                comments.append(__parse_comment(elem))
             elif elem.tag == "group":
-                group = parse_group(elem)
+                group = __parse_group(elem)
                 group_stack[-1].children.append(group)
                 group_stack.append(group)
         elif event == "end":
             if elem.tag == "parameters":
-                parameters = parse_parameters(elem)
+                parameters = __parse_parameters(elem)
             elif elem.tag == "thing":
                 current_tree = None
             elif elem.tag == "group":
@@ -287,7 +291,7 @@ def parse_nml(file):
     )
 
 
-def dump_bounding_box(xf, parameters, prefix):
+def __dump_bounding_box(xf, parameters, prefix):
     bboxName = prefix + "BoundingBox"
     parametersBox = getattr(parameters, bboxName)
 
@@ -305,7 +309,7 @@ def dump_bounding_box(xf, parameters, prefix):
         )
 
 
-def dump_parameters(xf, parameters):
+def __dump_parameters(xf, parameters):
     xf.startTag("parameters")
     xf.tag("experiment", {"name": parameters.name})
     xf.tag(
@@ -350,13 +354,13 @@ def dump_parameters(xf, parameters):
     if parameters.zoomLevel is not None:
         xf.tag("zoomLevel", {"zoom": str(parameters.zoomLevel)})
 
-    dump_bounding_box(xf, parameters, "task")
-    dump_bounding_box(xf, parameters, "user")
+    __dump_bounding_box(xf, parameters, "task")
+    __dump_bounding_box(xf, parameters, "user")
 
     xf.endTag()  # parameters
 
 
-def dump_node(xf, node):
+def __dump_node(xf, node):
 
     attributes = {
         "id": str(node.id),
@@ -391,11 +395,11 @@ def dump_node(xf, node):
     xf.tag("node", attributes)
 
 
-def dump_edge(xf, edge):
+def __dump_edge(xf, edge):
     xf.tag("edge", {"source": str(edge.source), "target": str(edge.target)})
 
 
-def dump_tree(xf, tree):
+def __dump_tree(xf, tree):
     attributes = {
         "id": str(tree.id),
         "color.r": str(tree.color[0]),
@@ -411,16 +415,16 @@ def dump_tree(xf, tree):
     xf.startTag("thing", attributes)
     xf.startTag("nodes")
     for n in tree.nodes:
-        dump_node(xf, n)
+        __dump_node(xf, n)
     xf.endTag()  # nodes
     xf.startTag("edges")
     for e in tree.edges:
-        dump_edge(xf, e)
+        __dump_edge(xf, e)
     xf.endTag()  # edges
     xf.endTag()  # thing
 
 
-def dump_branchpoint(xf, branchpoint):
+def __dump_branchpoint(xf, branchpoint):
     if branchpoint.time is not None:
         xf.tag(
             "branchpoint", {"id": str(branchpoint.id), "time": str(branchpoint.time)}
@@ -429,43 +433,46 @@ def dump_branchpoint(xf, branchpoint):
         xf.tag("branchpoint", {"id": str(branchpoint.id)})
 
 
-def dump_comment(xf, comment):
+def __dump_comment(xf, comment):
     if comment.content is not None:
         xf.tag("comment", {"node": str(comment.node), "content": comment.content})
     else:
         xf.tag("comment", {"node": str(comment.node)})
 
 
-def dump_group(xf, group):
+def __dump_group(xf, group):
     xf.startTag("group", {"id": str(group.id), "name": group.name})
     for g in group.children:
-        dump_group(xf, g)
+        __dump_group(xf, g)
     xf.endTag()  # group
 
 
-def dump_nml(xf, nml: NML):
+def __dump_nml(xf, nml: NML):
     xf.startTag("things")
-    dump_parameters(xf, nml.parameters)
+    __dump_parameters(xf, nml.parameters)
     for t in nml.trees:
-        dump_tree(xf, t)
+        __dump_tree(xf, t)
 
     xf.startTag("branchpoints")
     for b in nml.branchpoints:
-        dump_branchpoint(xf, b)
+        __dump_branchpoint(xf, b)
     xf.endTag()  # branchpoints
 
     xf.startTag("comments")
     for c in nml.comments:
-        dump_comment(xf, c)
+        __dump_comment(xf, c)
     xf.endTag()  # comments
 
     xf.startTag("groups")
     for g in nml.groups:
-        dump_group(xf, g)
+        __dump_group(xf, g)
     xf.endTag()  # groups
     xf.endTag()  # things
 
 
-def write_nml(file, nml: NML):
+def write_nml(file: BinaryIO, nml: NML):
+    ''' 
+        Writes an NML object to a file.
+    ''' 
     with XmlWriter(file) as xf:
-        dump_nml(xf, nml)
+        __dump_nml(xf, nml)

--- a/wknml/__init__.py
+++ b/wknml/__init__.py
@@ -8,6 +8,20 @@ IntVector6 = Tuple[int, int, int, int, int, int]
 
 
 class NMLParameters(NamedTuple):
+    '''
+    Contains common metadata for NML files
+
+    Attributes:
+        name (str): Foo
+        scale (Vector3): Foo
+        offset (Optional[Vector3]): Foo
+        time (Optional[int]): Foo
+        editPosition (Optional[Vector3]): Foo
+        editRotation (Optional[Vector3]): Foo
+        zoomLevel (Optional[float]): Foo
+        taskBoundingBox (Optional[IntVector6])
+        userBoundingBox (Optional[IntVector6])
+    '''
     name: str
     scale: Vector3
     offset: Optional[Vector3]
@@ -20,6 +34,20 @@ class NMLParameters(NamedTuple):
 
 
 class Node(NamedTuple):
+    '''
+    A webKnossos skeleton node annotation object.
+
+    Attributes:
+        id: int
+        position: Vector3
+        radius: Optional[float]
+        rotation: Optional[Vector3]
+        inVp: Optional[int]
+        inMag: Optional[int]
+        bitDepth: Optional[int]
+        interpolation: Optional[bool]
+        time: Optional[int]
+    '''
     id: int
     position: Vector3
     radius: Optional[float]
@@ -32,11 +60,29 @@ class Node(NamedTuple):
 
 
 class Edge(NamedTuple):
+    ''' 
+    A webKnossos skeleton edge.
+
+    Attributes:
+        source: int (node id reference)
+        target: int (node id reference)
+    ''' 
     source: int
     target: int
 
 
 class Tree(NamedTuple):
+    ''' 
+    A webKnossos skeleton (tree) object. A graph structure consisting of nodes and edges.
+
+    Attributes:
+        id: int
+        color: Vector4 (RGBA)
+        name: str
+        nodes: List[Node]
+        edges: List[Edge]
+        groupId: Optional[int] (group id reference)
+    ''' 
     id: int
     color: Vector4
     name: str
@@ -46,22 +92,54 @@ class Tree(NamedTuple):
 
 
 class Branchpoint(NamedTuple):
+    ''' 
+    A webKnossos branchpoint, i.e. a skeleton node with more than one outgoing edge.
+
+    Attributes:
+        id: int (node id reference)
+        time: int (Unix timestamp)
+    ''' 
     id: int
     time: int
 
 
 class Group(NamedTuple):
+    '''
+    A container to group several skeletons (trees) together. Mostly for cosmetic or organizational purposes.
+
+    Attributes:
+        id: int
+        name: str
+        children: List[Group]
+    '''
     id: int
     name: str
     children: List["Group"]
 
 
 class Comment(NamedTuple):
+    '''
+    A single comment belonging to a skeleton node.
+
+    Attributes:
+        node: int (node id reference)
+        content: str (supports Markdown)
+    ''' 
     node: int
     content: str
 
 
 class NML(NamedTuple):
+    '''
+    A complete webKnossos skeleton annotation object contain one or more skeletons (trees). 
+
+    Attributes:
+        parameters: NMLParameters
+        trees: List[Tree]
+        branchpoints: List[Branchpoint]
+        comments: List[Comment]
+        groups: List[Group]
+    ''' 
     parameters: NMLParameters
     trees: List[Tree]
     branchpoints: List[Branchpoint]
@@ -231,7 +309,17 @@ def __parse_group(nml_group):
 
 def parse_nml(file: BinaryIO) -> NML:
     '''
-        Parses a webKnossos NML skeleton file and returns an NML Python object
+    Reads a webKnossos NML skeleton file from disk, parses it and returns an NML Python object
+
+    Attributes:
+        file (BinaryIO): A Python file handle
+
+    Return:
+        NML: A webKnossos skeleton annotation as Python NML object
+
+    Example:
+        with open("input.nml", "rb") as f:
+            nml = wknml.parse_nml(f, nml)
     '''
 
     parameters = None
@@ -472,7 +560,15 @@ def __dump_nml(xf, nml: NML):
 
 def write_nml(file: BinaryIO, nml: NML):
     ''' 
-        Writes an NML object to a file.
+    Writes an NML object to a file on disk.
+
+    Arguments:
+        file (BinaryIO): A Python file handle
+        nml (NML): A NML object that should be persisted to disk 
+    
+    Example:
+        with open("out.nml", "wb") as f:
+            wknml.write_nml(f, nml)
     ''' 
     with XmlWriter(file) as xf:
         __dump_nml(xf, nml)

--- a/wknml/__init__.py
+++ b/wknml/__init__.py
@@ -326,8 +326,10 @@ def parse_nml(file: BinaryIO) -> NML:
         NML: A webKnossos skeleton annotation as Python NML object
 
     Example:
+        ```
         with open("input.nml", "rb") as f:
             nml = wknml.parse_nml(f, nml)
+        ```
     """
 
     parameters = None
@@ -570,13 +572,15 @@ def write_nml(file: BinaryIO, nml: NML):
     """
     Writes an NML object to a file on disk.
 
-    Arguments:
-        file (BinaryIO): A Python file handle
-        nml (NML): A NML object that should be persisted to disk
+        Arguments:
+            file (BinaryIO): A Python file handle
+            nml (NML): A NML object that should be persisted to disk
 
     Example:
+        ```
         with open("out.nml", "wb") as f:
             wknml.write_nml(f, nml)
+        ```
     """
     with XmlWriter(file) as xf:
         __dump_nml(xf, nml)

--- a/wknml/__init__.py
+++ b/wknml/__init__.py
@@ -1,103 +1,72 @@
 import xml.etree.ElementTree as ET
 from loxun import XmlWriter
 from typing import NamedTuple, List, Tuple, Optional
-import collections
 
 Vector3 = Tuple[float, float, float]
 Vector4 = Tuple[float, float, float, float]
 IntVector6 = Tuple[int, int, int, int, int, int]
 
-# From https://stackoverflow.com/a/18348004
-# Use the defaults parameter when switching to Python 3.6
-def NamedTupleWithDefaults(typename, field_names, default_values=()):
-    T = NamedTuple(typename, field_names)
-    T.__new__.__defaults__ = (None,) * len(T._fields)
-    if isinstance(default_values, collections.Mapping):
-        prototype = T(**default_values)
-    else:
-        prototype = T(*default_values)
-    T.__new__.__defaults__ = tuple(prototype)
-    return T
+
+class NMLParameters(NamedTuple):
+    name: str
+    scale: Vector3
+    offset: Optional[Vector3]
+    time: Optional[int]
+    editPosition: Optional[Vector3]
+    editRotation: Optional[Vector3]
+    zoomLevel: Optional[float]
+    taskBoundingBox: Optional[IntVector6]
+    userBoundingBox: Optional[IntVector6]
 
 
-NMLParameters = NamedTupleWithDefaults(
-    "NMLParameters",
-    [
-        ("name", str),
-        ("scale", Vector3),
-        ("offset", Optional[Vector3]),
-        ("time", Optional[int]),
-        ("editPosition", Optional[Vector3]),
-        ("editRotation", Optional[Vector3]),
-        ("zoomLevel", Optional[float]),
-        ("taskBoundingBox", Optional[IntVector6]),
-        ("userBoundingBox", Optional[IntVector6]),
-    ],
-    (None,) * 7,
-)
-Node = NamedTupleWithDefaults(
-    "Node",
-    [
-        ("id", int),
-        ("position", Vector3),
-        ("radius", Optional[float]),
-        ("rotation", Optional[Vector3]),
-        ("inVp", Optional[int]),
-        ("inMag", Optional[int]),
-        ("bitDepth", Optional[int]),
-        ("interpolation", Optional[bool]),
-        ("time", Optional[int]),
-    ],
-    (None,) * 7,
-)
-Edge = NamedTuple(
-    "Edge",
-    [
-        ("source", int),
-        ("target", int),
-    ],
-)
-Tree = NamedTupleWithDefaults(
-    "Tree",
-    [
-        ("id", int),
-        ("color", Vector4),
-        ("name", str),
-        ("nodes", List[Node]),
-        ("edges", List[Edge]),
-        ("groupId", Optional[int]),
-    ],
-    (None,) * 1,
-)
-Branchpoint = NamedTuple(
-    "Branchpoint",
-    [
-        ("id", int),
-        ("time", int),
-    ],
-)
-Group = NamedTuple(
-    "Group",
-    [("id", int), ("name", str), ("children", List["Group"])],
-)
-Comment = NamedTuple(
-    "Comment",
-    [
-        ("node", int),
-        ("content", str),
-    ],
-)
+class Node(NamedTuple):
+    id: int
+    position: Vector3
+    radius: Optional[float]
+    rotation: Optional[Vector3]
+    inVp: Optional[int]
+    inMag: Optional[int]
+    bitDepth: Optional[int]
+    interpolation: Optional[bool]
+    time: Optional[int]
 
-NML = NamedTuple(
-    "NML",
-    [
-        ("parameters", NMLParameters),
-        ("trees", List[Tree]),
-        ("branchpoints", List[Branchpoint]),
-        ("comments", List[Comment]),
-        ("groups", List[Group]),
-    ],
-)
+
+class Edge(NamedTuple):
+    source: int
+    target: int
+
+
+class Tree(NamedTuple):
+    id: int
+    color: Vector4
+    name: str
+    nodes: List[Node]
+    edges: List[Edge]
+    groupId: Optional[int]
+
+
+class Branchpoint(NamedTuple):
+    id: int
+    time: int
+
+
+class Group(NamedTuple):
+    id: int
+    name: str
+    children: List["Group"]
+
+
+class Comment(NamedTuple):
+    node: int
+    content: str
+
+
+class NML(NamedTuple):
+    parameters: NMLParameters
+    trees: List[Tree]
+    branchpoints: List[Branchpoint]
+    comments: List[Comment]
+    groups: List[Group]
 
 
 def parse_bounding_box(nml_parameters, prefix):


### PR DESCRIPTION
More house keeping:
- use standard named tuples and class for all objects
- renamed all internal methods
- added a few more type hints
- add doc strings
- generate API Docs automagically with `pydoc-markdown`
- bumped package version to `1.0.0` since the whole refactoring might be a breaking change and looks more serious :-D

Fixes https://github.com/scalableminds/wknml/issues/33, #28 