### PR TITLE
Fix read example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Some examples to get you started. Make sure to also check the `examples` directo
 ```python
 # Load an NML file
 with open("input.nml", "rb") as f:
-    nml = wknml.parse_nml(f, nml)
+    nml = wknml.parse_nml(f)
 
 # Access the most important properties
 print(nml.parameters)


### PR DESCRIPTION
It looks to me like there is a small mistake in the "nml loading" example in the README, because the parse_nml file doesn't take another parameter than the file handler.